### PR TITLE
Prepare version 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Unreleased Changes
 ------------------
 
+* Feature - [Major Version] Bump major version to 1.0.0.
+
+* Issue - Drop support for any non-aws prefixed configuration keys.
+
+* Issue - Drop support for the `:dynamodb_store` configuration name.
+
+* Feature - Bump `aws-sessionstore-dynamodb` dependency to `~> 3`.
+
 0.1.0 (2024-11-16)
 ------------------
 

--- a/aws-actiondispatch-dynamodb.gemspec
+++ b/aws-actiondispatch-dynamodb.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license      = 'Apache-2.0'
   spec.files        = Dir['LICENSE', 'CHANGELOG.md', 'VERSION', 'lib/**/*']
 
-  spec.add_dependency('aws-sessionstore-dynamodb', '~> 2')
+  spec.add_dependency('aws-sessionstore-dynamodb', '~> 3')
 
   spec.add_dependency('actionpack', '>= 7.1.0')
   spec.add_dependency('railties', '>= 7.1.0')


### PR DESCRIPTION
Drops legacy behavior and bumps dependencies.

Not to be merged until after aws-sdk-rails 5.